### PR TITLE
Remove useless comma to silence build warnings

### DIFF
--- a/include/android/log.h
+++ b/include/android/log.h
@@ -85,7 +85,7 @@ typedef enum android_LogPriority {
     ANDROID_LOG_WARN,
     ANDROID_LOG_ERROR,
     ANDROID_LOG_FATAL,
-    ANDROID_LOG_SILENT,     /* only for SetMinPriority(); must be last */
+    ANDROID_LOG_SILENT      /* only for SetMinPriority(); must be last */
 } android_LogPriority;
 
 /*


### PR DESCRIPTION
My build log is full of warnings about this trailing comma at the end of this enum list:
include/android/log.h:88

I can't see how removing the comma could hurt, but it should save us the warning spam.
