### PR TITLE
Bug 1043112

### DIFF
--- a/rootdir/init.rc
+++ b/rootdir/init.rc
@@ -1,4 +1,5 @@
 import /init.${ro.hardware}.rc
+import /init.b2g.debug.rc
 
 on early-init
     # Set init and its forked children's oom_adj.


### PR DESCRIPTION
Bug 1043112 - Temporarily have init.rc import debug rc to enable core dumps directly.
